### PR TITLE
Add player customization (color picker, name, settings menu)

### DIFF
--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -75,7 +75,7 @@ const webSwing = new WebSwing(scene, thirdPersonCamera.camera);
 const remotePlayers: Map<string, RemotePlayer> = new Map();
 
 // Generate a random player name
-const playerName = `Spider-${Math.floor(Math.random() * 1000)}`;
+let playerName = `Spider-${Math.floor(Math.random() * 1000)}`;
 
 // Network connection
 const SERVER_URL = `ws://${window.location.hostname}:3002`; // Sprint branch uses different port
@@ -290,11 +290,10 @@ document.getElementById('settings-save')?.addEventListener('click', () => {
   const newColor = colorInput.value;
 
   if (newName && newName !== playerName) {
-    // Note: playerName is const, so we update the display only
-    // The server will track the actual name
+    playerName = newName;
     const statusEl = document.getElementById('network-status');
     if (statusEl) {
-      statusEl.textContent = `Connected as ${newName}`;
+      statusEl.textContent = `Connected as ${playerName}`;
     }
   }
 

--- a/packages/client/src/network/Connection.ts
+++ b/packages/client/src/network/Connection.ts
@@ -7,14 +7,15 @@ import type {
   JoinMessage,
   PositionUpdate,
   SwingUpdate,
+  SettingsUpdate,
 } from '@kids-game/shared';
 
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'full';
 
 export interface ConnectionEvents {
   onStatusChange: (status: ConnectionStatus) => void;
-  onWelcome: (yourId: string, existingPlayers: Array<{ id: string; name: string }>) => void;
-  onPlayerJoined: (id: string, name: string) => void;
+  onWelcome: (yourId: string, existingPlayers: Array<{ id: string; name: string; color: string }>) => void;
+  onPlayerJoined: (id: string, name: string, color: string) => void;
   onPlayerLeft: (id: string) => void;
   onGameState: (players: PlayerData[]) => void;
 }
@@ -87,7 +88,7 @@ export class Connection {
         break;
 
       case 'player_joined':
-        this.events.onPlayerJoined(message.id, message.name);
+        this.events.onPlayerJoined(message.id, message.name, message.color);
         break;
 
       case 'player_left':
@@ -149,6 +150,16 @@ export class Connection {
       type: 'swing',
       active,
       attachPoint,
+    };
+    this.send(msg);
+  }
+
+  // Send settings update (name, color)
+  sendSettings(name?: string, color?: string): void {
+    const msg: SettingsUpdate = {
+      type: 'settings',
+      name,
+      color,
     };
     this.send(msg);
   }

--- a/packages/client/src/player/Player.ts
+++ b/packages/client/src/player/Player.ts
@@ -35,24 +35,32 @@ export class Player {
   private eyeGlowMaterial: THREE.MeshStandardMaterial | null = null;
   private bodyGlowRing: THREE.Mesh | null = null;
 
+  // Body material for color customization
+  private bodyMaterial: THREE.MeshStandardMaterial;
+
   constructor(input: Input) {
     this.input = input;
+    this.bodyMaterial = new THREE.MeshStandardMaterial({
+      color: 0xdd1111, // Default red
+      metalness: 0.8,
+      roughness: 0.2,
+    });
     this.mesh = this.createMesh();
+  }
+
+  // Change player color
+  setColor(color: string): void {
+    this.bodyMaterial.color.set(color);
   }
 
   private createMesh(): THREE.Group {
     const group = new THREE.Group();
 
-    // === BODY ===
+    // === BODY (uses customizable color material) ===
     // Main abdomen (larger back section)
     const abdomenGeometry = new THREE.SphereGeometry(0.45, 20, 16);
     abdomenGeometry.scale(1, 0.8, 1.2);
-    const bodyMaterial = new THREE.MeshStandardMaterial({
-      color: 0xdd1111,
-      metalness: 0.8,
-      roughness: 0.2,
-    });
-    const abdomen = new THREE.Mesh(abdomenGeometry, bodyMaterial);
+    const abdomen = new THREE.Mesh(abdomenGeometry, this.bodyMaterial);
     abdomen.position.set(0, 0.5, -0.15);
     abdomen.castShadow = true;
     group.add(abdomen);
@@ -60,7 +68,7 @@ export class Player {
     // Thorax (middle section)
     const thoraxGeometry = new THREE.SphereGeometry(0.35, 16, 12);
     thoraxGeometry.scale(1, 0.9, 0.9);
-    const thorax = new THREE.Mesh(thoraxGeometry, bodyMaterial);
+    const thorax = new THREE.Mesh(thoraxGeometry, this.bodyMaterial);
     thorax.position.set(0, 0.55, 0.2);
     thorax.castShadow = true;
     group.add(thorax);
@@ -81,15 +89,10 @@ export class Player {
     // Tech patterns on abdomen (circuit lines)
     this.addCircuitPattern(group, abdomen.position, 0.45);
 
-    // === HEAD ===
+    // === HEAD (uses same customizable color material) ===
     const headGeometry = new THREE.SphereGeometry(0.22, 14, 10);
     headGeometry.scale(1, 0.9, 1.1);
-    const headMaterial = new THREE.MeshStandardMaterial({
-      color: 0xdd1111,
-      metalness: 0.8,
-      roughness: 0.2,
-    });
-    const head = new THREE.Mesh(headGeometry, headMaterial);
+    const head = new THREE.Mesh(headGeometry, this.bodyMaterial);
     head.position.set(0, 0.7, 0.45);
     head.castShadow = true;
     group.add(head);

--- a/packages/client/src/player/RemotePlayer.ts
+++ b/packages/client/src/player/RemotePlayer.ts
@@ -207,6 +207,23 @@ export class RemotePlayer {
     }
   }
 
+  // Update player name and recreate label
+  setName(name: string): void {
+    if (this.name !== name) {
+      this.name = name;
+      // Remove old label
+      if (this.nameSprite) {
+        const material = this.nameSprite.material as THREE.SpriteMaterial;
+        material.map?.dispose();
+        material.dispose();
+        this.mesh.remove(this.nameSprite);
+        this.nameSprite = null;
+      }
+      // Create new label
+      this.createNameLabel();
+    }
+  }
+
   // Update from network data
   updateFromData(data: PlayerData): void {
     this.targetPosition.set(data.x, data.y, data.z);
@@ -215,6 +232,11 @@ export class RemotePlayer {
     // Update color if changed
     if (data.color !== this.color) {
       this.setColor(data.color);
+    }
+
+    // Update name if changed
+    if (data.name !== this.name) {
+      this.setName(data.name);
     }
 
     // Update web line if swinging

--- a/packages/server/src/GameState.ts
+++ b/packages/server/src/GameState.ts
@@ -3,6 +3,7 @@ import type { PlayerData, PlayerState, Vector3 } from '@kids-game/shared';
 interface PlayerSession {
   id: string;
   name: string;
+  color: string;
   x: number;
   y: number;
   z: number;
@@ -21,11 +22,29 @@ export class GameState {
     return this.players.size < this.MAX_PLAYERS;
   }
 
+  // Generate a random vibrant color for new players
+  private generateRandomColor(): string {
+    const colors = [
+      '#ff4444', // Red
+      '#44ff44', // Green
+      '#4444ff', // Blue
+      '#ffff44', // Yellow
+      '#ff44ff', // Magenta
+      '#44ffff', // Cyan
+      '#ff8800', // Orange
+      '#8844ff', // Purple
+      '#ff4488', // Pink
+      '#44ff88', // Mint
+    ];
+    return colors[Math.floor(Math.random() * colors.length)];
+  }
+
   // Add a new player
   addPlayer(id: string, name: string): PlayerSession {
     const player: PlayerSession = {
       id,
       name,
+      color: this.generateRandomColor(),
       x: 0,
       y: 1,
       z: 0,
@@ -47,12 +66,27 @@ export class GameState {
     return this.players.get(id);
   }
 
-  // Get all connected player IDs and names
-  getPlayerList(): Array<{ id: string; name: string }> {
+  // Get all connected player IDs, names, and colors
+  getPlayerList(): Array<{ id: string; name: string; color: string }> {
     return Array.from(this.players.values()).map(p => ({
       id: p.id,
       name: p.name,
+      color: p.color,
     }));
+  }
+
+  // Update player settings (name, color)
+  updateSettings(id: string, name?: string, color?: string): void {
+    const player = this.players.get(id);
+    if (player) {
+      if (name !== undefined && name.length > 0 && name.length <= 20) {
+        player.name = name;
+      }
+      if (color !== undefined && /^#[0-9a-fA-F]{6}$/.test(color)) {
+        player.color = color;
+      }
+      player.lastUpdate = Date.now();
+    }
   }
 
   // Update player position
@@ -90,6 +124,7 @@ export class GameState {
     return Array.from(this.players.values()).map(p => ({
       id: p.id,
       name: p.name,
+      color: p.color,
       x: p.x,
       y: p.y,
       z: p.z,

--- a/packages/server/src/PlayerSession.ts
+++ b/packages/server/src/PlayerSession.ts
@@ -75,6 +75,15 @@ export class PlayerSession {
           this.gameState.updateSwing(this.id, message.active, message.attachPoint);
         }
         break;
+      case 'settings':
+        if (this.joined) {
+          this.gameState.updateSettings(this.id, message.name, message.color);
+          // Update local name if changed
+          if (message.name) {
+            this.name = message.name;
+          }
+        }
+        break;
     }
   }
 
@@ -88,7 +97,7 @@ export class PlayerSession {
     }
 
     this.name = name || `Player ${this.id.slice(0, 4)}`;
-    this.gameState.addPlayer(this.id, this.name);
+    const player = this.gameState.addPlayer(this.id, this.name);
     this.joined = true;
 
     console.log(`[${this.id}] ${this.name} joined (${this.gameState.playerCount} players)`);
@@ -101,11 +110,12 @@ export class PlayerSession {
     };
     this.send(welcome);
 
-    // Notify other players
+    // Notify other players (include color from the newly created player)
     const joinMsg: PlayerJoinedMessage = {
       type: 'player_joined',
       id: this.id,
       name: this.name,
+      color: player.color,
     };
     this.broadcast(joinMsg, this.id);
   }

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -24,7 +24,13 @@ export interface SwingUpdate {
   attachPoint?: Vector3;
 }
 
-export type ClientMessage = JoinMessage | PositionUpdate | SwingUpdate;
+export interface SettingsUpdate {
+  type: 'settings';
+  name?: string; // Optional new name
+  color?: string; // Optional new color (hex)
+}
+
+export type ClientMessage = JoinMessage | PositionUpdate | SwingUpdate | SettingsUpdate;
 
 // ============================================
 // Server -> Client Messages
@@ -33,13 +39,14 @@ export type ClientMessage = JoinMessage | PositionUpdate | SwingUpdate;
 export interface WelcomeMessage {
   type: 'welcome';
   yourId: string;
-  players: Array<{ id: string; name: string }>;
+  players: Array<{ id: string; name: string; color: string }>;
 }
 
 export interface PlayerJoinedMessage {
   type: 'player_joined';
   id: string;
   name: string;
+  color: string;
 }
 
 export interface PlayerLeftMessage {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -12,6 +12,7 @@ export interface Vector3 {
 export interface PlayerData {
   id: string;
   name: string;
+  color: string; // Hex color like "#ff0000"
   x: number;
   y: number;
   z: number;


### PR DESCRIPTION
## Summary
- Players can now customize their spider color and name
- ESC key opens a settings menu overlay
- Random vibrant colors assigned on player join

## Changes

### Shared Types (`packages/shared`)
- Added `color: string` to `PlayerData` interface
- Added `SettingsUpdate` message type
- Updated `WelcomeMessage` and `PlayerJoinedMessage` to include color

### Server (`packages/server`)
- `GameState.ts`:
  - Added `generateRandomColor()` - picks from 10 vibrant colors
  - Added `updateSettings()` - validates and updates name/color
  - Updated `addPlayer()` to assign random color
  - Updated `getPlayerList()` and `getAllPlayerData()` to include color
- `PlayerSession.ts`:
  - Handle new `settings` message type
  - Include color in `player_joined` broadcast

### Client (`packages/client`)
- `Player.ts`:
  - Added `bodyMaterial` class property for shared color
  - Added `setColor()` method to update body color
- `RemotePlayer.ts`:
  - Accept color in constructor
  - Added `setColor()` method
  - Update color dynamically from network state
- `Connection.ts`:
  - Updated callbacks to include color parameter
  - Added `sendSettings()` method
- `main.ts`:
  - Added settings overlay UI (ESC to toggle)
  - Color picker input
  - Name input (max 20 chars)
  - Save/Cancel buttons
  - Updated instructions to show ESC shortcut

## Test plan
- [ ] New players spawn with random colors
- [ ] Press ESC opens settings menu
- [ ] Change color in settings, save - spider color updates
- [ ] Change name in settings, save - displayed name updates
- [ ] Other players see the new color/name
- [ ] ESC or Cancel closes settings without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)