### PR TITLE
Add WebRTC voice chat

### DIFF
--- a/packages/client/src/network/VoiceChat.ts
+++ b/packages/client/src/network/VoiceChat.ts
@@ -1,0 +1,218 @@
+import type { Connection } from './Connection';
+
+interface PeerConnection {
+  connection: RTCPeerConnection;
+  remoteStream: MediaStream | null;
+  audioElement: HTMLAudioElement;
+}
+
+export class VoiceChat {
+  private localStream: MediaStream | null = null;
+  private peers: Map<string, PeerConnection> = new Map();
+  private networkConnection: Connection;
+  private enabled: boolean = false;
+  private myId: string = '';
+
+  // ICE servers for NAT traversal (using public STUN servers)
+  private readonly rtcConfig: RTCConfiguration = {
+    iceServers: [
+      { urls: 'stun:stun.l.google.com:19302' },
+      { urls: 'stun:stun1.l.google.com:19302' },
+    ],
+  };
+
+  constructor(connection: Connection) {
+    this.networkConnection = connection;
+  }
+
+  setMyId(id: string): void {
+    this.myId = id;
+  }
+
+  async enable(): Promise<boolean> {
+    if (this.enabled) return true;
+
+    try {
+      // Request microphone access
+      this.localStream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+      this.enabled = true;
+      console.log('[VoiceChat] Microphone enabled');
+      return true;
+    } catch (err) {
+      console.error('[VoiceChat] Failed to get microphone:', err);
+      return false;
+    }
+  }
+
+  disable(): void {
+    if (!this.enabled) return;
+
+    // Stop local stream
+    if (this.localStream) {
+      this.localStream.getTracks().forEach(track => track.stop());
+      this.localStream = null;
+    }
+
+    // Close all peer connections
+    this.peers.forEach((peer, id) => {
+      this.closePeer(id);
+    });
+    this.peers.clear();
+
+    this.enabled = false;
+    console.log('[VoiceChat] Disabled');
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  // Called when a new player joins - initiate connection to them
+  async connectToPeer(peerId: string): Promise<void> {
+    if (!this.enabled || !this.localStream) return;
+    if (this.peers.has(peerId)) return;
+
+    console.log(`[VoiceChat] Connecting to peer ${peerId}`);
+
+    const peerConnection = new RTCPeerConnection(this.rtcConfig);
+    const audioElement = document.createElement('audio');
+    audioElement.autoplay = true;
+
+    const peer: PeerConnection = {
+      connection: peerConnection,
+      remoteStream: null,
+      audioElement,
+    };
+    this.peers.set(peerId, peer);
+
+    // Add local tracks to the connection
+    this.localStream.getTracks().forEach(track => {
+      peerConnection.addTrack(track, this.localStream!);
+    });
+
+    // Handle incoming tracks
+    peerConnection.ontrack = (event) => {
+      console.log(`[VoiceChat] Received track from ${peerId}`);
+      peer.remoteStream = event.streams[0];
+      audioElement.srcObject = event.streams[0];
+    };
+
+    // Handle ICE candidates
+    peerConnection.onicecandidate = (event) => {
+      if (event.candidate) {
+        this.networkConnection.sendRTCIceCandidate(peerId, event.candidate.toJSON());
+      }
+    };
+
+    // Create and send offer
+    try {
+      const offer = await peerConnection.createOffer();
+      await peerConnection.setLocalDescription(offer);
+      this.networkConnection.sendRTCOffer(peerId, offer);
+    } catch (err) {
+      console.error(`[VoiceChat] Failed to create offer for ${peerId}:`, err);
+    }
+  }
+
+  // Called when we receive an offer from another peer
+  async handleOffer(fromId: string, offer: RTCSessionDescriptionInit): Promise<void> {
+    if (!this.enabled || !this.localStream) return;
+
+    console.log(`[VoiceChat] Received offer from ${fromId}`);
+
+    // If we already have a connection, close it
+    if (this.peers.has(fromId)) {
+      this.closePeer(fromId);
+    }
+
+    const peerConnection = new RTCPeerConnection(this.rtcConfig);
+    const audioElement = document.createElement('audio');
+    audioElement.autoplay = true;
+
+    const peer: PeerConnection = {
+      connection: peerConnection,
+      remoteStream: null,
+      audioElement,
+    };
+    this.peers.set(fromId, peer);
+
+    // Add local tracks
+    this.localStream.getTracks().forEach(track => {
+      peerConnection.addTrack(track, this.localStream!);
+    });
+
+    // Handle incoming tracks
+    peerConnection.ontrack = (event) => {
+      console.log(`[VoiceChat] Received track from ${fromId}`);
+      peer.remoteStream = event.streams[0];
+      audioElement.srcObject = event.streams[0];
+    };
+
+    // Handle ICE candidates
+    peerConnection.onicecandidate = (event) => {
+      if (event.candidate) {
+        this.networkConnection.sendRTCIceCandidate(fromId, event.candidate.toJSON());
+      }
+    };
+
+    // Set remote description and create answer
+    try {
+      await peerConnection.setRemoteDescription(new RTCSessionDescription(offer));
+      const answer = await peerConnection.createAnswer();
+      await peerConnection.setLocalDescription(answer);
+      this.networkConnection.sendRTCAnswer(fromId, answer);
+    } catch (err) {
+      console.error(`[VoiceChat] Failed to handle offer from ${fromId}:`, err);
+    }
+  }
+
+  // Called when we receive an answer to our offer
+  async handleAnswer(fromId: string, answer: RTCSessionDescriptionInit): Promise<void> {
+    const peer = this.peers.get(fromId);
+    if (!peer) return;
+
+    console.log(`[VoiceChat] Received answer from ${fromId}`);
+
+    try {
+      await peer.connection.setRemoteDescription(new RTCSessionDescription(answer));
+    } catch (err) {
+      console.error(`[VoiceChat] Failed to set answer from ${fromId}:`, err);
+    }
+  }
+
+  // Called when we receive an ICE candidate
+  async handleIceCandidate(fromId: string, candidate: RTCIceCandidateInit): Promise<void> {
+    const peer = this.peers.get(fromId);
+    if (!peer) return;
+
+    try {
+      await peer.connection.addIceCandidate(new RTCIceCandidate(candidate));
+    } catch (err) {
+      console.error(`[VoiceChat] Failed to add ICE candidate from ${fromId}:`, err);
+    }
+  }
+
+  // Called when a player leaves
+  disconnectPeer(peerId: string): void {
+    this.closePeer(peerId);
+    this.peers.delete(peerId);
+  }
+
+  private closePeer(peerId: string): void {
+    const peer = this.peers.get(peerId);
+    if (peer) {
+      peer.connection.close();
+      if (peer.audioElement.srcObject) {
+        peer.audioElement.srcObject = null;
+      }
+      console.log(`[VoiceChat] Disconnected from ${peerId}`);
+    }
+  }
+
+  dispose(): void {
+    this.disable();
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,14 @@ function broadcast(message: ServerMessage, excludeId?: string): void {
   });
 }
 
+// Send a message to a specific player by ID
+function sendToPlayer(targetId: string, message: ServerMessage): void {
+  const session = sessions.get(targetId);
+  if (session && session.isJoined) {
+    session.send(message);
+  }
+}
+
 // Handle session disconnect
 function handleDisconnect(id: string): void {
   sessions.delete(id);
@@ -44,7 +52,7 @@ function handleDisconnect(id: string): void {
 const wss = new WebSocketServer({ server });
 
 wss.on('connection', (ws: WebSocket) => {
-  const session = new PlayerSession(ws, gameState, broadcast, handleDisconnect);
+  const session = new PlayerSession(ws, gameState, broadcast, sendToPlayer, handleDisconnect);
   sessions.set(session.id, session);
   console.log(`Connection from ${session.id}`);
 });

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -30,7 +30,33 @@ export interface SettingsUpdate {
   color?: string; // Optional new color (hex)
 }
 
-export type ClientMessage = JoinMessage | PositionUpdate | SwingUpdate | SettingsUpdate;
+// WebRTC signaling messages
+export interface RTCOfferMessage {
+  type: 'rtc_offer';
+  targetId: string;
+  offer: RTCSessionDescriptionInit;
+}
+
+export interface RTCAnswerMessage {
+  type: 'rtc_answer';
+  targetId: string;
+  answer: RTCSessionDescriptionInit;
+}
+
+export interface RTCIceCandidateMessage {
+  type: 'rtc_ice';
+  targetId: string;
+  candidate: RTCIceCandidateInit;
+}
+
+export type ClientMessage =
+  | JoinMessage
+  | PositionUpdate
+  | SwingUpdate
+  | SettingsUpdate
+  | RTCOfferMessage
+  | RTCAnswerMessage
+  | RTCIceCandidateMessage;
 
 // ============================================
 // Server -> Client Messages
@@ -63,9 +89,31 @@ export interface ServerFullMessage {
   type: 'server_full';
 }
 
+// Relayed WebRTC signaling messages (from another player)
+export interface RTCOfferRelayMessage {
+  type: 'rtc_offer';
+  fromId: string;
+  offer: RTCSessionDescriptionInit;
+}
+
+export interface RTCAnswerRelayMessage {
+  type: 'rtc_answer';
+  fromId: string;
+  answer: RTCSessionDescriptionInit;
+}
+
+export interface RTCIceCandidateRelayMessage {
+  type: 'rtc_ice';
+  fromId: string;
+  candidate: RTCIceCandidateInit;
+}
+
 export type ServerMessage =
   | WelcomeMessage
   | PlayerJoinedMessage
   | PlayerLeftMessage
   | GameStateMessage
-  | ServerFullMessage;
+  | ServerFullMessage
+  | RTCOfferRelayMessage
+  | RTCAnswerRelayMessage
+  | RTCIceCandidateRelayMessage;


### PR DESCRIPTION
## Summary
- Add peer-to-peer voice chat using WebRTC
- Server relays signaling messages only (offers, answers, ICE candidates)
- Voice toggle in settings menu (ESC) with status indicator
- Auto-connects to all existing/new players when enabled

## Test plan
- [ ] Open settings (ESC), enable voice chat
- [ ] Confirm microphone permission prompt appears
- [ ] With 2+ players, verify voice audio works both directions
- [ ] Toggle off voice chat, confirm connections close
- [ ] Re-enable voice chat, confirm it reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)